### PR TITLE
add android support

### DIFF
--- a/src/distro.rs
+++ b/src/distro.rs
@@ -1,11 +1,3 @@
-pub fn exit_code() -> i32 {
-    let status = std::process::Command::new("sh")
-        .args(&["-c", "which getprop > /dev/null 2>&1"])
-        .status()
-        .expect("");
-    status.code().unwrap()
-}
-
 pub fn dist(path: &str) -> std::io::Result<String> {
     let file = std::fs::File::open(path)?;
     let line: String = crate::shared_functions::line(file, 0); // Expects NAME= to be on first line

--- a/src/distro.rs
+++ b/src/distro.rs
@@ -1,3 +1,11 @@
+pub fn exit_code() -> i32 {
+    let status = std::process::Command::new("sh")
+        .args(&["-c", "which getprop > /dev/null 2>&1"])
+        .status()
+        .expect("");
+    status.code().unwrap()
+}
+
 pub fn dist(path: &str) -> std::io::Result<String> {
     let file = std::fs::File::open(path)?;
     let line: String = crate::shared_functions::line(file, 0); // Expects NAME= to be on first line

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,15 @@ pub fn gpu() -> io::Result<String> {
 
 /// Obtain the hostname, outputs to a Result<String>
 pub fn hostname() -> io::Result<String> {
-    Ok(read_to_string("/etc/hostname")?.trim().to_string())
+    if shared_functions::exit_code() != 1 {
+        let output_hostname = std::process::Command::new("sh")
+            .args(&["-c", "hostname"])
+            .output()
+            .expect("");
+        Ok(String::from_utf8_lossy(&output_hostname.stdout).trim().to_string())
+    } else {
+        Ok(read_to_string("/etc/hostname")?.trim().to_string())
+    }
 }
 
 /// Obtain the kernel version, outputs to a Result<String>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,11 @@ pub fn cpu() -> io::Result<String> {
             false => info(file, 4),
         }
     } else {
-        info(file, 4)
+        if shared_functions::exit_code() != 1 {
+            info(file, 1)
+        } else {
+            info(file, 4)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,36 @@ pub fn cpu() -> io::Result<String> {
 
 /// Obtain name of device, outputs to a string
 pub fn device() -> io::Result<String> {
-    let model = read_to_string("/sys/devices/virtual/dmi/id/product_name")
-        .or_else(|_| read_to_string("/sys/firmware/devicetree/base/model"))?;
-    Ok(model.trim().replace("\n", ""))
+    if shared_functions::exit_code() != 1 {
+        let output_product = std::process::Command::new("sh")
+            .args(&["-c", "getprop ro.product.name"])
+            .output()
+            .expect("");
+        let product = String::from_utf8_lossy(&output_product.stdout).trim().to_string();
+        let output_model = std::process::Command::new("sh")
+            .args(&["-c", "getprop ro.product.model"])
+            .output()
+            .expect("");
+        let model = String::from_utf8_lossy(&output_model.stdout).trim().to_string();
+        let output_device = std::process::Command::new("sh")
+            .args(&["-c", "getprop ro.product.device"])
+            .output()
+            .expect("");
+        let device = String::from_utf8_lossy(&output_device.stdout).trim().to_string();
+        let full = [
+            product, 
+            " ".to_string(), 
+            model, 
+            " (".to_string(), 
+            device, 
+            ")".to_string()
+        ].concat();
+        Ok(full)
+    } else {
+        let model = read_to_string("/sys/devices/virtual/dmi/id/product_name")
+            .or_else(|_| read_to_string("/sys/firmware/devicetree/base/model"))?;
+        Ok(model.trim().replace("\n", ""))
+    }
 }
 
 /// Obtain the distro name, outputs to a string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,29 @@ pub fn environment() -> io::Result<String> {
 
 /// Obtain the contents of the env variable specified as an arg, outputs to a string
 pub fn env(var: &str) -> Option<String> {
-    Some(env::var(var).unwrap_or_else(|_| format!("N/A (could not read ${}, are you sure it's set?)", var)))
+    if shared_functions::exit_code() != 1 {
+        if var == "USER" {
+            let output_user = std::process::Command::new("sh")
+                .args(&["-c", "whoami"])
+                .output()
+                .expect("");
+            Some(String::from_utf8_lossy(&output_user.stdout).trim().to_string())
+        } else {
+            Some(
+                env::var(var)
+                .unwrap_or_else(
+                    |_| format!("N/A (could not read ${}, are you sure it's set?)", var)
+                    )
+                )
+        }
+    } else {
+        Some(
+            env::var(var)
+            .unwrap_or_else(
+                |_| format!("N/A (could not read ${}, are you sure it's set?)", var)
+                )
+            )
+    }
 }
 
 fn r#continue(output_check: String) -> io::Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,14 +46,20 @@ pub fn device() -> io::Result<String> {
 
 /// Obtain the distro name, outputs to a string
 pub fn distro() -> io::Result<String> {
-    if distro::exit_code() != 1 {
-        let output = std::process::Command::new("sh")
+    if shared_functions::exit_code() != 1 {
+        let output_distro = std::process::Command::new("sh")
             .args(&["-c", "getprop ro.build.version.release"])
             .output()
             .expect("");
-        let mut distro = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let mut distro = String::from_utf8_lossy(&output_distro.stdout).trim().to_string();
         distro = ["Android ".to_string(), distro].concat();
-        Ok(distro)
+        let output_flavor = std::process::Command::new("sh")
+            .args(&["-c", "getprop ro.build.flavor"])
+            .output()
+            .expect("");
+        let flavor = String::from_utf8_lossy(&output_flavor.stdout).trim().to_string();
+        let full = [distro, " (".to_string(), flavor, ")".to_string()].concat();
+        Ok(full)
 
     } else {
         let distro = distro::dist("/bedrock/etc/os-release")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,21 @@ pub fn device() -> io::Result<String> {
 
 /// Obtain the distro name, outputs to a string
 pub fn distro() -> io::Result<String> {
-    let distro = distro::dist("/bedrock/etc/os-release")
-        .or_else(|_| distro::dist("/etc/os-release"))
-        .or_else(|_| distro::dist("/usr/lib/os-release"))?;
-    Ok(distro)
+    if distro::exit_code() != 1 {
+        let output = std::process::Command::new("sh")
+            .args(&["-c", "getprop ro.build.version.release"])
+            .output()
+            .expect("");
+        let mut distro = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        distro = ["Android ".to_string(), distro].concat();
+        Ok(distro)
+
+    } else {
+        let distro = distro::dist("/bedrock/etc/os-release")
+            .or_else(|_| distro::dist("/etc/os-release"))
+            .or_else(|_| distro::dist("/usr/lib/os-release"))?;
+        Ok(distro)
+    }
 }
 
 /// Obtains the name of the user's DE or WM, outputs to a string

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -1,6 +1,15 @@
 use std::fs::File;
 use std::io::{BufReader, Read};
 
+/// Returns the exit code of `which getprop > /dev/null 2>&1"`
+pub fn exit_code() -> i32 {
+    let status = std::process::Command::new("sh")
+        .args(&["-c", "which getprop > /dev/null 2>&1"])
+        .status()
+        .expect("");
+    status.code().unwrap()
+}
+
 pub fn read(file: File) -> Result<String, Box<dyn std::error::Error>> {
     let mut buf_reader = BufReader::new(file);
     let mut contents = String::new();


### PR DESCRIPTION
This PR updates the info fields; cpu, device, distro, hostname, and user to be better supported on Android.

Example output from rsfetch on my Moto E4 phone:

`$ ./target/debug/rsfetch -cDdhkmsuUC 0`:

```
0─────────────────────────────────────────────────────0
│ CPU      │ ARMv7 Processor rev 4 (v7l)              │
│ Device   │ Moto E4 XT1765 (perry)                   │
│ Distro   │ Android 7.1.2 (aokp_perry-userdebug)     │
│ Hostname │ localhost                                │
│ Kernel   │ 3.18.63-NPL26.118-20-g9365253            │
│ Memory   │ 1868 MB                                  │
│ Shell    │ /data/data/com.termux/files/usr/bin/bash │
│ Uptime   │ 14h 50m                                  │
│ User     │ u0_a73                                   │
0─────────────────────────────────────────────────────0
```