### PR TITLE
Faster count and apt package retriving method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ pub fn packages(manager: &str) -> io::Result<String> {
         }
         "apt" | "dpkg" => {
             let output = Command::new("dpkg").args(&["--get-selections"]).output()?;
-            Ok(format!("{}", packages::count(output) - 1)) // -1 to deal with "Listing..."
+            Ok(format!("{}", packages::count(output)))
         }
         "dnf" => {
             let output = Command::new("dnf").args(&["list", "installed"]).output()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,9 +258,7 @@ pub fn packages(manager: &str) -> io::Result<String> {
             Ok(format!("{}", packages::count(output)))
         }
         "apt" => {
-            let output = Command::new("apt")
-                .args(&["list", "--installed"])
-                .output()?;
+            let output = Command::new("dpkg").args(&["--get-selections"]).output()?;
             Ok(format!("{}", packages::count(output) - 1)) // -1 to deal with "Listing..."
         }
         "dnf" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,9 @@ pub fn packages(manager: &str) -> io::Result<String> {
             Ok(format!("{}", packages::count(output)))
         }
         "apt" => {
-            let output = Command::new("dpkg").args(&["--get-selections"]).output()?;
+            let output = Command::new("apt")
+                .args(&["list", "--installed"])
+                .output()?;
             Ok(format!("{}", packages::count(output) - 1)) // -1 to deal with "Listing..."
         }
         "dnf" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,9 +258,7 @@ pub fn packages(manager: &str) -> io::Result<String> {
             Ok(format!("{}", packages::count(output)))
         }
         "apt" => {
-            let output = Command::new("dpkg")
-                .args(&["--get-selections"])
-                .output()?;
+            let output = Command::new("dpkg").args(&["--get-selections"]).output()?;
             Ok(format!("{}", packages::count(output) - 1)) // -1 to deal with "Listing..."
         }
         "dnf" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,8 +258,8 @@ pub fn packages(manager: &str) -> io::Result<String> {
             Ok(format!("{}", packages::count(output)))
         }
         "apt" => {
-            let output = Command::new("apt")
-                .args(&["list", "--installed"])
+            let output = Command::new("dpkg")
+                .args(&["--get-selections"])
                 .output()?;
             Ok(format!("{}", packages::count(output) - 1)) // -1 to deal with "Listing..."
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,18 +257,12 @@ pub fn packages(manager: &str) -> io::Result<String> {
             let output = Command::new("apk").arg("info").output()?;
             Ok(format!("{}", packages::count(output)))
         }
-        "apt" => {
+        "apt" | "dpkg" => {
             let output = Command::new("dpkg").args(&["--get-selections"]).output()?;
             Ok(format!("{}", packages::count(output) - 1)) // -1 to deal with "Listing..."
         }
         "dnf" => {
             let output = Command::new("dnf").args(&["list", "installed"]).output()?;
-            Ok(format!("{}", packages::count(output)))
-        }
-        "dpkg" => {
-            let output = Command::new("dpkg-query")
-                .args(&["-f", "'${binary:Package}\n'", "-W"])
-                .output()?;
             Ok(format!("{}", packages::count(output)))
         }
         "eopkg" => {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,4 +1,11 @@
-pub fn count(output: std::process::Output) -> usize {
+//pub fn count(output: std::process::Output) -> usize {
   // -1 to deal with newline at end of output
-  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
+//  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
+//}
+
+
+pub fn count(output: std::process::Output) -> usize {
+  let raw_list = String::from_utf8_lossy(&output.stdout);
+  let list: Vec<&str> = raw_list.split('\n').collect();
+  list.iter().count() - 1 // -1 to deal with newline at end of output
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,11 +1,4 @@
-//pub fn count(output: std::process::Output) -> usize {
-  // -1 to deal with newline at end of output
-//  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
-//}
-
-
 pub fn count(output: std::process::Output) -> usize {
-  let raw_list = String::from_utf8_lossy(&output.stdout);
-  let list: Vec<&str> = raw_list.split('\n').collect();
-  list.iter().count() - 1 // -1 to deal with newline at end of output
+  // -1 to deal with newline at end of output
+  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,4 +1,4 @@
 pub fn count(output: std::process::Output) -> usize {
   // -1 to deal with newline at end of output
-  output.stdout.iter().filter(|&i| i == b'\n').count() - 1
+  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,4 +1,4 @@
 pub fn count(output: std::process::Output) -> usize {
-    // -1 to deal with newline at end of output
-    String::from_utf8_lossy(&output.stdout).split('\n').count() - 1
-  }
+  // -1 to deal with newline at end of output
+  output.stdout.iter().filter(|&i| i == b'\n').count() - 1
+}

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,5 +1,4 @@
 pub fn count(output: std::process::Output) -> usize {
-    let raw_list = String::from_utf8_lossy(&output.stdout);
-    let list: Vec<&str> = raw_list.split('\n').collect();
-    list.iter().count() - 1 // -1 to deal with newline at end of output
-}
+    // -1 to deal with newline at end of output
+    String::from_utf8_lossy(&output.stdout).split('\n').count() - 1
+  }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,4 +1,4 @@
 pub fn count(output: std::process::Output) -> usize {
   // -1 to deal with newline at end of output
-  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
+  String::from_utf8_lossy(&output.stdout).split('\n').count() - 1
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -1,4 +1,4 @@
 pub fn count(output: std::process::Output) -> usize {
   // -1 to deal with newline at end of output
-  String::from_utf8_lossy(&output.stdout).split('\n').count() - 1
+  output.stdout.iter().filter(|&&i| i == b'\n').count() - 1
 }


### PR DESCRIPTION
I noticed that retrieving total package count was slowing down the output and was quite jarring.
So I have proposed a new package retrieval method as well as new counting method that is quicker

| Method                      	| Time to complete execution 	|
|------------------------------	|--------------------------------------------------------	|
| stock                        	| real    0.38s user    0.32s sys     0.06s cpu     100% 	|
| dpkg w/ stock count          	| real    0.36s user    0.31s sys     0.06s cpu     99%  	|
| stock w/ new counting method 	| real    0.37s user    0.33s sys     0.04s cpu     99%  	|
| dpkg w/ new counting method  	| real    0.08s user    0.04s sys     0.04s cpu     97%  	|

These are the numbers I got during my test, I have not tried this on other systems other than a laptop and a pc