### PR TITLE
Used memory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ To use: `nixinfo = "0.3.2"` in your `Cargo.toml`.
 - Kernel
   + `nixinfo::kernel()` -> `Result<String>`
 - Total memory in MBs
-  + `nixinfo::memory()` -> `Result<String>`
+  + `nixinfo::memory_total()` -> `Result<String>`
+- Free memory in MBs
+  + `nixinfo::memory_free()` -> `Result<String>`
+- Available memory in MBs
++ `nixinfo::memory_available()` -> `Result<String>`
+- Used memory in MBs
++ `nixinfo::memory_used()` -> `Result<String>`
 - Music info
   + Features for this:
     * `music_mpd` for music info from mpd

--- a/README.md
+++ b/README.md
@@ -39,5 +39,4 @@ To use: `nixinfo = "0.3.2"` in your `Cargo.toml`.
 
 ## TODO
 
-- Obtain used memory in addition to total memory
 - Support *BSD

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,58 @@
+use std::fs::{self};
+use std::io::{self, Error};
+
+pub fn memory(mem_value: &str) -> Result<u64, Error> {
+    let no_mem_info_error_msg: &str = &format!("No memoryinfo in {} line!", mem_value);
+    let no_memline_found_error_msg: &str = &format!("No {} line found in /proc/meminfo", mem_value);
+    const MEMINFO: &str = "/proc/meminfo";
+    const UNIT: [&str; 5] = ["kB", "MB", "GB", "TB", "PB"];
+    const SEPARATOR_COLON: &str = ":";
+    const EMPTY_STRING: &str = "";
+
+    pub trait ToIoResult<T> {
+        fn to_io_result(self) -> io::Result<T>;
+    }
+
+    impl<T, E: ToString> ToIoResult<T> for Result<T, E> {
+        fn to_io_result(self) -> io::Result<T> {
+            match self {
+                Ok(x) => Ok(x),
+                Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
+            }
+        }
+    }
+
+    let meminfo = fs::read_to_string(MEMINFO)?;
+    for line in meminfo.lines() {
+        if line.starts_with(mem_value) {
+            let mut rsplit = line.rsplit(SEPARATOR_COLON);
+            let size = match rsplit.next() {
+                Some(x) => x
+                    .replace(UNIT[0], EMPTY_STRING)
+                    .trim()
+                    .parse::<u64>()
+                    .to_io_result()?,
+                None => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    no_memline_found_error_msg,
+                ))?,
+            };
+            return Ok(size);
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::Other, no_mem_info_error_msg))?
+}
+
+pub fn memory_formatter(mem_result: Result<u64, Error>) -> Result<String, Error> {
+    if mem_result.is_err() {
+        return Err(mem_result.unwrap_err());
+    }
+
+    const DIVISOR_U64: u64 = 1024;
+    const UNIT_MB: &str = "MB";
+    return Ok(format!(
+        "{} {}",
+        (mem_result.unwrap() / DIVISOR_U64),
+        UNIT_MB
+    ));
+}


### PR DESCRIPTION
# Used Memory Support for nixinfo

- implement separate functions `memory_total()`, `memory_free()`, `memory_available()`, `memory_used()`
- move the base meminfo-reader function `memory()` to a separate `memory` module just like `cpu` and others
- extract formatting to `memory_formatter()` in `memory` module

`memory_used()` calculates used memory amount like utilities like `htop`, so basically: `MemTotal - MemFree`